### PR TITLE
Adding LLM Providers

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,5 +1,6 @@
 from .agent import *
+from .callbacks import *
 from .generic import *
 from .processors import BatchProcessor, DFBatchProcessor
-from .callbacks import *
+from .providers import *
 from .stopping_conditions import *

--- a/agents/abstract.py
+++ b/agents/abstract.py
@@ -56,8 +56,8 @@ class _Agent(metaclass=abc.ABCMeta):
 
     def __init__(
         self,
-        model_name: Optional[str],
         stopping_condition: _StoppingCondition,
+        model_name: Optional[str] = None,
         provider: Optional[_Provider] = None,
         tools: Optional[List[dict]] = None,
         callbacks: Optional[List[Callable]] = None,

--- a/agents/agent/base.py
+++ b/agents/agent/base.py
@@ -1,18 +1,14 @@
 import json
 import logging
-import os
-import re
-from copy import deepcopy, copy
-from typing import Any, Callable, Optional
+from copy import copy, deepcopy
+from typing import Any, Callable
 
-import backoff
 import openai
-from azure.identity import ClientSecretCredential
-from openai.types.chat.chat_completion import ChatCompletionMessage
 from pydantic import BaseModel
 
 from ..abstract import _Agent
 from ..decorators import response_model_handler
+from ..providers import AzureOpenAIProvider
 from ..stopping_conditions import StopOnDataModel
 
 logger = logging.getLogger(__name__)
@@ -47,13 +43,13 @@ class Agent(_Agent):
     This is still quite experimental, but the intended usecase is for reflection / refinement applications.
     """
 
-    def __init__(self, model_name, stopping_condition, llm = None, tools = None, callbacks = None, oai_kwargs = None, **fmt_kwargs):
+    def __init__(self, model_name, stopping_condition, provider = None, tools = None, callbacks = None, oai_kwargs = None, **fmt_kwargs):
         """
         Base Agent class
 
-        :param str model_name: Name of OpenAI model to use (or deployment name for AzureOpenAI)
+        :param str model_name: Name of model to use (or deployment name for AzureOpenAI)
         :param _StoppingCondition stopping_condition: A handler that signals when an Agent has completed the task
-        :param AsyncOpenAI llm: Instantiated OpenAI instance to use (optional)
+        :param Type[_Provider] provider: Instantiated OpenAI instance to use (optional)
         :param List[dict] tools: List of tools the agent can call via response (optional)
         :param List[Callable] callbacks: List of callbacks to evaluate at end of run (optional)
         :param dict[str, any] oai_kwargs: Dict of additional OpenAI arguments to pass thru to chat call
@@ -63,12 +59,10 @@ class Agent(_Agent):
         self.stopping_condition = stopping_condition
         # We default to Azure OpenAI here, but
         # we could also use something else as long as it follows the OpenAI API
-        if llm is None:
-            self.authenticate()
-            self.llm = openai.AsyncAzureOpenAI()
+        if provider is None:
+            self.provider = AzureOpenAIProvider(model_name=model_name)
         else:
-            self.llm = llm
-        self.model_name = model_name
+            self.provider = provider
         
         # Handle Tools
         self.TOOLS = getattr(self, "TOOLS", [])
@@ -142,7 +136,7 @@ class Agent(_Agent):
         n_retry = 3
         while response is None and n_retry > 0:
             try:
-                response = await self.prompt_agent(llm_prompt_input)
+                response = await self.provider.prompt_agent(self, llm_prompt_input, **self.oai_kwargs)
             except json.decoder.JSONDecodeError as e:
                 if n_retry == 0:
                     raise e
@@ -201,102 +195,6 @@ class Agent(_Agent):
         Simple helper function to clean response text, if desired
         """
         out = res.strip('\n').strip().replace('\n', '')
-        return out
-
-    @staticmethod
-    def authenticate():
-        """
-        Authenticate against Azure OpenAI using Service Principal
-        
-        HACK: Obviously this assumes we use AzureOpenAI, so we could modularize this
-        """
-        # === Service Principal auth ========================
-        credential = ClientSecretCredential(
-            tenant_id=os.environ["SP_TENANT_ID"],
-            client_id=os.environ["SP_CLIENT_ID"],
-            client_secret=os.environ["SP_CLIENT_SECRET"],
-        )
-
-        os.environ["AZURE_OPENAI_API_KEY"] = credential.get_token(
-            "https://cognitiveservices.azure.com/.default"
-        ).token
-
-        os.environ["AZURE_OPENAI_ENDPOINT"] = os.environ["GPT4_URL"]
-
-    @backoff.on_exception(backoff.expo, (openai.APIError, openai.AuthenticationError), max_tries=3)
-    async def prompt_agent(self, prompt, **addn_oai_kwargs):
-        """
-        An async version of the main OAI prompting logic.
-
-        :param prompt: Either a dict or a list of dicts representing the message(s) to send to OAI model
-        :param addn_oai_kwargs: Key word arguments passed to completions.create() call (tool calls, etc.)
-
-        :return: An openAI Choice response object
-        """
-
-        # Prompts should be passed as a list, so handle
-        # the case where we just passed a single dict
-        if isinstance(prompt, dict):
-            prompt = [prompt]
-
-        self.scratchpad += f"--- Input ---------------------------\n"
-        self.scratchpad += "\n".join(msg["content"] for msg in prompt if not isinstance(msg, ChatCompletionMessage))
-        self.scratchpad += "\n-----------------------------------\n"
-    
-        try:
-            res = await self.llm.chat.completions.create(
-                messages=prompt, model=self.model_name,
-                **addn_oai_kwargs,
-                **self.oai_kwargs
-            )
-        except openai.AuthenticationError:
-            logger.info("Auth failed, attempting to re-authenticate before retrying")
-            # HACK: This isn't terrific, but it should work for
-            # our current use case (Azure OpenAI with service principal/User creds)
-            if isinstance(self.llm, openai.AzureOpenAI):
-                self.authenticate()
-                self.llm.api_key = os.environ["AZURE_OPENAI_API_KEY"]
-            raise e
-        except Exception as e:
-            # TODO: some error handling here
-            logger.debug(e)
-            raise e
-
-        out = res.choices[0]
-
-        self.scratchpad += "--- Output --------------------------\n"
-        self.scratchpad += "Message:\n"
-        self.scratchpad += out.message.content if out.message.content else "<None>" + "\n"
-
-        if len(self.TOOLS):
-            # attempt to parse tool call arguments
-            if out.finish_reason == "tool_calls":
-                # Append GPT response to next payload
-                # NOTE: This has to come before the next step of parsing
-                self.tool_res_payload.append(deepcopy(out.message))
-
-                self.scratchpad += "Tool calls: \n"
-                for i, tool in enumerate(out.message.tool_calls):
-                    try:
-                        assert tool.function.name in self._known_tools
-                    except Exception as e:
-                        self.tool_res_payload.pop()
-                        raise e
-
-                    out.message.tool_calls[i].function.arguments = json.loads(tool.function.arguments)
-
-                    # Log it
-                    toolcall_str = f"{tool.function.name}({str(tool.function.arguments)[:50] + '...(trunc)' if len(str(tool.function.arguments)) > 50 else str(tool.function.arguments)})"
-                    logger.info(f"Got toolcall: {toolcall_str}")
-                    self.scratchpad += f"\t=> {toolcall_str}\n"
-        
-        self.scratchpad += "\n-----------------------------------\n"
-        logger.info(f"Received response: {out.message.content}")
-
-        if out.finish_reason == "length":
-            self.truncated = True
-            self.scratchpad += "Response returned truncated from OpenAI due to token length.\n"
-            logger.warning("Message returned truncated.")
         return out
 
     def format_prompt(self) -> str:
@@ -390,7 +288,7 @@ class StructuredOutputAgent(Agent):
     """
     answer: dict[str, Any]
 
-    def __init__(self, response_model: type[BaseModel], model_name: str, stopping_condition=None, llm=None, tools=None, callbacks=None, oai_kwargs=None, **fmt_kwargs):
+    def __init__(self, response_model: type[BaseModel], model_name: str, stopping_condition=None, provider=None, tools=None, callbacks=None, oai_kwargs=None, **fmt_kwargs):
         """
         Language Agent with structured output
 
@@ -400,7 +298,7 @@ class StructuredOutputAgent(Agent):
         :param BaseModel response_model: A data model to use for structured output
         :param str model_name: Name of OpenAI model to use (or deployment name for AzureOpenAI)
         :param _StoppingCondition stopping_condition: A handler that signals when an Agent has completed the task
-        :param AsyncOpenAI llm: Instantiated OpenAI instance to use (optional)
+        :param Type[_Provider] provider: Instantiated OpenAI instance to use (optional)
         :param List[dict] tools: List of tools the agent can call via response (optional)
         :param List[Callable] callbacks: List of callbacks to evaluate at end of run (optional)
         :param dict[str, any] oai_kwargs: Dict of additional OpenAI arguments to pass thru to chat call
@@ -429,7 +327,7 @@ class StructuredOutputAgent(Agent):
         fun_name = oai_tool["function"]["name"]
         setattr(self, fun_name, response_model_handler(self.response_model))
 
-        super().__init__(model_name, stopping_condition, llm, tools_internal, callbacks, oai_kwargs, **fmt_kwargs)
+        super().__init__(model_name, stopping_condition, provider, tools_internal, callbacks, oai_kwargs, **fmt_kwargs)
     
     def reset(self) -> None:
         """

--- a/agents/agent/prediction.py
+++ b/agents/agent/prediction.py
@@ -27,9 +27,9 @@ class PredictionAgent(StructuredOutputAgent):
     def __init__(
         self,
         labels: list[str],
-        model_name: str,
         expected_len: Optional[int] = None,
         stopping_condition: Optional[_StoppingCondition] = None,
+        model_name: Optional[str] = None,
         provider: Optional[Type[_Provider]] = None,
         tools: Optional[List[dict]] = None,
         callbacks: Optional[List[Callable]] = None,
@@ -41,9 +41,9 @@ class PredictionAgent(StructuredOutputAgent):
         
         
         :param labels: The set of categorical labels the model can choose from
-        :param str model_name: Name of OpenAI model to use (or deployment name for AzureOpenAI)
         :param int expected_len: Optional length constraint on the response_model (OpenAI API doesn't allow maxItems parameter in schema so this is checked post-hoc in the Pydantic BaseModel)
         :param _StoppingCondition stopping_condition: A handler that signals when an Agent has completed the task (optional)
+        :param str model_name: Name of model to use (or deployment name for AzureOpenAI) (optional if provider is passed)
         :param Type[_Provider] provider: Instantiated OpenAI instance to use (optional)
         :param List[dict] tools: List of tools the agent can call via response (optional)
         :param List[Callable] callbacks: List of callbacks to evaluate at end of run (optional)

--- a/agents/agent/prediction.py
+++ b/agents/agent/prediction.py
@@ -4,13 +4,12 @@ Sean Browning (oet5)
 """
 
 import logging
-from typing import Callable, List, Literal, Optional, Any
+from typing import Callable, List, Literal, Optional, Any, Type
 
-import openai
 import pydantic
 
-from ..abstract import _StoppingCondition
-from .base import Agent, StructuredOutputAgent
+from ..abstract import _StoppingCondition, _Provider
+from .base import StructuredOutputAgent
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +30,7 @@ class PredictionAgent(StructuredOutputAgent):
         model_name: str,
         expected_len: Optional[int] = None,
         stopping_condition: Optional[_StoppingCondition] = None,
-        llm: Optional[openai.AsyncOpenAI] = None,
+        provider: Optional[Type[_Provider]] = None,
         tools: Optional[List[dict]] = None,
         callbacks: Optional[List[Callable]] = None,
         oai_kwargs: Optional[dict[str, Any]] = None,
@@ -45,7 +44,7 @@ class PredictionAgent(StructuredOutputAgent):
         :param str model_name: Name of OpenAI model to use (or deployment name for AzureOpenAI)
         :param int expected_len: Optional length constraint on the response_model (OpenAI API doesn't allow maxItems parameter in schema so this is checked post-hoc in the Pydantic BaseModel)
         :param _StoppingCondition stopping_condition: A handler that signals when an Agent has completed the task (optional)
-        :param AsyncOpenAI llm: Instantiated OpenAI instance to use (optional)
+        :param Type[_Provider] provider: Instantiated OpenAI instance to use (optional)
         :param List[dict] tools: List of tools the agent can call via response (optional)
         :param List[Callable] callbacks: List of callbacks to evaluate at end of run (optional)
         :param dict[str, any] oai_kwargs: Dict of additional OpenAI arguments to pass thru to chat call
@@ -58,7 +57,7 @@ class PredictionAgent(StructuredOutputAgent):
             response_model,
             model_name=model_name,
             stopping_condition=stopping_condition,
-            llm=llm,
+            provider=provider,
             tools=tools,
             callbacks=callbacks,
             oai_kwargs=oai_kwargs,

--- a/agents/providers/__init__.py
+++ b/agents/providers/__init__.py
@@ -1,1 +1,1 @@
-from azure_openai import AzureOpenAIProvider
+from .azure_openai import AzureOpenAIProvider

--- a/agents/providers/__init__.py
+++ b/agents/providers/__init__.py
@@ -1,0 +1,1 @@
+from azure_openai import AzureOpenAIProvider

--- a/examples/agent_with_callback.py
+++ b/examples/agent_with_callback.py
@@ -5,7 +5,6 @@ Sean Browning
 import asyncio
 import agents
 import logging
-import openai
 import dotenv
 
 # NOTE: This loads in env vars for openAI
@@ -41,19 +40,18 @@ class DummyEvaluatorAgent(agents.Agent):
 if __name__ == "__main__":
 
     # Run this with Interactive OAuth
-    agents.openai_creds_ad("Interactive")
-
-    llm = openai.AsyncAzureOpenAI()
+    prov = agents.AzureOpenAIProvider(
+        "gpt-4o-mini-nofilter",
+        interactive=True
+    )
 
     ag = DummyAgent(
-        model_name = "edav-api-share-gpt4-api-nofilter",
         stopping_condition=agents.StopOnStep(1),
-        llm=llm,
+        provider=prov,
         callbacks=[
             agents.AgentCallback(
                 DummyEvaluatorAgent,
-                model_name="edav-api-share-gpt4-api-nofilter",
-                llm=llm,
+                provider=prov,
                 stopping_condition=agents.StopOnStep(1)
             )
         ],

--- a/examples/batch_processing.py
+++ b/examples/batch_processing.py
@@ -13,7 +13,6 @@ from pydantic import BaseModel, Field
 from typing import List, Literal
 import logging
 import dotenv
-import openai
 
 N_QUESTIONS = 20
 BATCH_SIZE = 5
@@ -74,14 +73,15 @@ class QAnswerer(agents.StructuredOutputAgent):
 
 if __name__ == "__main__":
     # Run this with Interactive OAuth
-    agents.openai_creds_ad("Interactive")
-
-    llm = openai.AsyncAzureOpenAI()
+    prov = agents.AzureOpenAIProvider(
+        # "gpt-4o-mini-nofilter",
+        "GPT35-Turbo-0613",
+        interactive=True
+    )
 
     ag = QAGenerator(
         response_model=QuestionandAnswer,
-        model_name = "edav-api-share-gpt4-api-nofilter",
-        llm = llm,
+        provider=prov,
         oai_kwargs={"temperature": 1.0},
         n_questions=N_QUESTIONS
     )
@@ -95,9 +95,9 @@ if __name__ == "__main__":
         data=ag.answer["question"],
         agent_class=QAnswerer,
         batch_size=BATCH_SIZE,
+        provider=prov,
         n_workers=3,
         response_model=Answer,
-        model_name = "edav-api-share-gpt4-api-nofilter",
         oai_kwargs={"temperature": 0.0}
     )
 

--- a/examples/structured_prediction.py
+++ b/examples/structured_prediction.py
@@ -11,7 +11,6 @@ from pydantic import BaseModel, Field
 from typing import List, Literal
 import logging
 import dotenv
-import openai
 
 # NOTE: This loads in env vars for openAI
 dotenv.load_dotenv()
@@ -59,14 +58,14 @@ class QAnswerer(agents.StructuredOutputAgent):
 
 if __name__ == "__main__":
     # Run this with Interactive OAuth
-    agents.openai_creds_ad("Interactive")
-
-    llm = openai.AsyncAzureOpenAI()
+    prov = agents.AzureOpenAIProvider(
+        "gpt-4o-mini-nofilter",
+        interactive=True
+    )
 
     ag = QAGenerator(
         response_model=QuestionandAnswer,
-        model_name = "edav-api-share-gpt4-api-nofilter",
-        llm = llm,
+        provider = prov,
         oai_kwargs={"temperature": 1.0},
         n_questions=5
     )
@@ -77,8 +76,7 @@ if __name__ == "__main__":
 
     ag2 = QAnswerer(
         response_model=Answer,
-        model_name = "edav-api-share-gpt4-api-nofilter",
-        llm = llm,
+        provider = prov,
         oai_kwargs={"temperature": 1.0},
         questions=ag.answer["question"]
     )

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", encoding="utf-8") as readme_file:
 
 setup(
     name='agents',
-    version='0.3.0-20250107',
+    version='0.3.0-20250117',
     description='Yet another langchain-esque package to use language agents and compose agent-systems',
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Changes
- LLM platform specific methods (authentication, prompt) are now encapsulated in a new `Provider` class, which is added
  - Ultimately this should make things much easier to expand down the road for running LLM locally, Gemini, etc.
- `model_name` is now optional arg, since this can be passed to Provider prior to Agent init 
- Cleaning up a few silly hard codes from earlier days