### PR TITLE
Auto-generating JSON payload for OpenAI tool calling using type hints

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -4,4 +4,4 @@ from .generic import *
 from .processors import BatchProcessor, DFBatchProcessor
 from .providers import *
 from .stopping_conditions import *
-from .json_tool_gen import agent_callable
+from .json_tool_gen import agent_callable, async_agent_callable

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -4,3 +4,4 @@ from .generic import *
 from .processors import BatchProcessor, DFBatchProcessor
 from .providers import *
 from .stopping_conditions import *
+from .json_tool_gen import agent_callable

--- a/agents/agent/base.py
+++ b/agents/agent/base.py
@@ -8,7 +8,7 @@ import openai
 from pydantic import BaseModel, ValidationError
 
 from ..abstract import _Agent
-from ..json_tool_gen import agent_callable
+from ..json_tool_gen import AgentCallable
 from ..providers import AzureOpenAIProvider
 from ..stopping_conditions import StopOnDataModel
 
@@ -303,7 +303,7 @@ class Agent(_Agent):
         for obj in dir(self):
             if (
                 callable(getattr(self, obj))
-                and getattr(getattr(self, obj), "agent_callable", False) is True
+                and isinstance(getattr(self, obj), AgentCallable)
             ):
                 payload.append(getattr(getattr(self, obj), "agent_json_payload"))
 

--- a/agents/agent/base.py
+++ b/agents/agent/base.py
@@ -8,7 +8,6 @@ import openai
 from pydantic import BaseModel, ValidationError
 
 from ..abstract import _Agent
-from ..json_tool_gen import AgentCallable
 from ..providers import AzureOpenAIProvider
 from ..stopping_conditions import StopOnDataModel
 

--- a/agents/agent/base.py
+++ b/agents/agent/base.py
@@ -303,9 +303,9 @@ class Agent(_Agent):
         for obj in dir(self):
             if (
                 callable(getattr(self, obj))
-                and isinstance(getattr(self, obj), AgentCallable)
+                and len(getattr(getattr(self, obj), "agent_tool_payload", []))
             ):
-                payload.append(getattr(getattr(self, obj), "agent_json_payload"))
+                payload.append(getattr(getattr(self, obj), "agent_tool_payload"))
 
         return payload
 

--- a/agents/agent/base.py
+++ b/agents/agent/base.py
@@ -1,13 +1,14 @@
 import json
 import logging
 from copy import copy, deepcopy
-from typing import Any, Callable, Optional
 from inspect import iscoroutinefunction
+from typing import Any, Callable, Optional
 
 import openai
 from pydantic import BaseModel, ValidationError
 
 from ..abstract import _Agent
+from ..json_tool_gen import agent_callable
 from ..providers import AzureOpenAIProvider
 from ..stopping_conditions import StopOnDataModel
 
@@ -69,6 +70,9 @@ class Agent(_Agent):
 
         if tools is not None:
             self.TOOLS.extend(tools)
+
+        # Add any methods defined with decorator
+        self.TOOLS.extend(self._check_agent_callable_methods())
 
         # Handle Callbacks
         self.CALLBACKS = getattr(self, "CALLBACKS", [])
@@ -289,6 +293,21 @@ class Agent(_Agent):
         """
         with open(outfile, "w", encoding="utf-8") as file:
             file.writelines(elem + "\n" for elem in self.scratchpad.split("\n"))
+
+    def _check_agent_callable_methods(self):
+        """
+        Scans class for methods that are flagged as agent callable via decorator
+        which alleviates some boilerplate for manually defining JSON schema along with method
+        """
+        payload = []
+        for obj in dir(self):
+            if (
+                callable(getattr(self, obj))
+                and getattr(getattr(self, obj), "agent_callable", False) is True
+            ):
+                payload.append(getattr(getattr(self, obj), "agent_json_payload"))
+
+        return payload
 
 class StructuredOutputAgent(Agent):
     """

--- a/agents/json_tool_gen.py
+++ b/agents/json_tool_gen.py
@@ -163,3 +163,31 @@ def agent_callable(description: str, variable_description: dict[str, str]):
         return wrapper
 
     return agent_callable_wrapper
+
+def async_agent_callable(description: str, variable_description: dict[str, str]):
+    """
+    Marks a coroutine as accessible to a language agent
+    and generates required JSON payload by extracting type hints.
+
+    Args:
+        description (str): A description of the function which will be shared with the language agent
+        variable_description (dict[str, str]): A dict with entries for each variable of the function describing what each variable is
+    """
+
+    def agent_callable_wrapper(func: Callable):
+
+        @functools.wraps(func)
+        async def wrapper(*args, **kwargs):
+            result = await func(*args, **kwargs)
+            return result
+
+        # Generate the JSON payload needed for OpenAI Function Calling API
+        # and assign it to an attribute we can extract at Agent init time
+        json_payload = generate_tool_json_payload(
+            func, description, variable_description
+        )
+        setattr(wrapper, "agent_tool_payload", json_payload)
+
+        return wrapper
+
+    return agent_callable_wrapper

--- a/agents/json_tool_gen.py
+++ b/agents/json_tool_gen.py
@@ -82,7 +82,7 @@ class AgentCallable:
 
         for arg, hint in hints.items():
             try:
-                arg_properties = arg_to_oai_type(hint)
+                arg_properties = self.arg_to_oai_type(hint)
             except KeyError as e:
                 raise KeyError("Processing arg {} failed. {}".format(arg, str(e)))
             arg_properties["description"] = self.variable_description[arg]

--- a/agents/json_tool_gen.py
+++ b/agents/json_tool_gen.py
@@ -4,10 +4,9 @@ using python type hints and a thin decorator
 
 Sean Browning
 """
-from functools import wraps
+from functools import update_wrapper
 import inspect
 from typing import (
-    Optional,
     List,
     Union,
     Callable,
@@ -30,107 +29,116 @@ PYTHON_TO_OAI_SCHEMA = {
     NoneType: "null",
 }
 
+class AgentCallable:
+    def __init__(self, func: Callable, description: str, variable_description: Dict[str, str]):
+        self.description = description
+        self.variable_description = variable_description
+        self.func = func
+        self.agent_json_payload = self.generate_tool_json_payload()
 
-def arg_to_oai_type(arg: Any) -> Dict[str, Any]:
-    """
-    Converting Python type hint to OpenAI type for JSON payload.
+    def __call__(self, *args, **kwargs):
+        result = self.func(*args, **kwargs)
+        return result
 
-    Args:
-        arg (Any): A type hint for a specific argument of a function
-    Returns:
-        Dict[str, str]: Detailing the argument type and any possible choices (if a Literal or List)
-    Raises:
-        KeyError if type is not an interpretable type for OpenAI
-    """
-    origin = get_origin(arg)
-    args = get_args(arg)
-
-    if origin is list or origin is List:
-        item_type = arg_to_oai_type(args[0]) if args else {"type": "any"}
-        return {"type": "array", "items": item_type}
-    elif origin is dict or origin is Dict:
-        return {"type": "object"}
-    elif origin is Literal:
-        return {"type": "string", "enum": list(args)}
-    elif origin is Union:
-        # If >1 option, we have to run multiple times and aggregate results
-        union_types = [arg_to_oai_type(py_type) for py_type in args]
-        out: Dict[str, Union[List[str], str]] = {}
-
-        for union_type in union_types:
-            for key, value in union_type.items():
-                if key in out:
-                    if isinstance(out[key], list):
-                        out[key].append(value)
-                    else:
-                        out[key] = [out[key], value]
-                else:
-                    out[key] = value
-
-        return out
-    elif arg in PYTHON_TO_OAI_SCHEMA:
-        return {"type": PYTHON_TO_OAI_SCHEMA[arg]}
-    else:
-        raise KeyError(
-            "Type {} is not an interpretable type for OpenAI.".format(str(arg))
+    def generate_tool_json_payload(self) -> Dict[str, Any]:
+        """
+        Internal function used to generate OpenAI Function Calling JSON payload from function type hints.
+        """
+        hints = get_type_hints(self.func)
+        hints.pop("result", None) # Ignore return type
+        sig = inspect.signature(self.func)
+        missing_annotations = (set(sig.parameters.keys()) ^ {"self"}) - set(hints.keys())
+        missing_descriptions = (set(sig.parameters.keys()) ^ {"self"}) - set(
+            self.variable_description.keys()
         )
 
-
-def generate_tool_json_payload(
-    func: Callable, description: str, variable_description: Dict[str, str]
-) -> Dict[str, Any]:
-    """
-    Internal function used to generate OpenAI Function Calling JSON payload from function type hints.
-
-    Args:
-        func (Callable): The function to extract type hints from
-        description (str): A Description of the function
-    """
-    hints = get_type_hints(func)
-    sig = inspect.signature(func)
-    missing_annotations = (set(sig.parameters.keys()) ^ {"self"}) - set(hints.keys())
-    missing_descriptions = (set(sig.parameters.keys()) ^ {"self"}) - set(
-        variable_description.keys()
-    )
-
-    if len(missing_annotations) > 0:
-        raise ValueError(
-            "agent_callable requires type hints for every argument! Missing type hints for {}: {}.".format(
-                func.__name__, ", ".join(missing_annotations)
+        if len(missing_annotations) > 0:
+            raise ValueError(
+                "agent_callable requires type hints for every argument! Missing type hints for {}: {}.".format(
+                    self.func.__name__, ", ".join(missing_annotations)
+                )
             )
-        )
-    if len(missing_descriptions):
-        raise ValueError(
-            "agent_callable requires descriptions for every argument! Missing description for {}: {}.".format(
-                func.__name__, ", ".join(missing_descriptions)
+        if len(missing_descriptions):
+            raise ValueError(
+                "agent_callable requires descriptions for every argument! Missing description for {}: {}.".format(
+                    self.func.__name__, ", ".join(missing_descriptions)
+                )
             )
-        )
 
-    tool_json = {
-        "type": "function",
-        "function": {
-            "name": func.__name__,
-            "description": description,
-            "parameters": {
-                "type": "object",
-                "properties": {},
-                "required": [variable for variable in sig.parameters.keys()],
-                "addnProperties": False,
+        tool_json = {
+            "type": "function",
+            "function": {
+                "name": self.func.__name__,
+                "description": self.description,
+                "parameters": {
+                    "type": "object",
+                    "properties": {},
+                    "required": [variable for variable in hints.keys()],
+                    "additionalProperties": False,
+                },
+                "strict": True,
             },
-            "strict": True,
-        },
-    }
+        }
 
-    for arg, hint in hints.items():
-        try:
-            arg_properties = arg_to_oai_type(hint)
-        except KeyError as e:
-            raise KeyError("Processing arg {} failed. {}".format(arg, str(e)))
-        arg_properties["description"] = variable_description[arg]
-        tool_json["function"]["parameters"]["properties"].update({arg: arg_properties})
+        for arg, hint in hints.items():
+            try:
+                arg_properties = arg_to_oai_type(hint)
+            except KeyError as e:
+                raise KeyError("Processing arg {} failed. {}".format(arg, str(e)))
+            arg_properties["description"] = self.variable_description[arg]
+            tool_json["function"]["parameters"]["properties"].update({arg: arg_properties})
 
-    return tool_json
+        return tool_json
+    
+    @staticmethod
+    def arg_to_oai_type(arg: Any) -> Dict[str, Any]:
+        """
+        Converting Python type hint to OpenAI type for JSON payload.
 
+        Args:
+            arg (Any): A type hint for a specific argument of a function
+        Returns:
+            Dict[str, str]: Detailing the argument type and any possible choices (if a Literal or List)
+        Raises:
+            KeyError if type is not an interpretable type for OpenAI
+        """
+        origin = get_origin(arg)
+        args = get_args(arg)
+
+        if origin is list or origin is List:
+            item_type = AgentCallable.arg_to_oai_type(args[0]) if args else {"type": "any"}
+            return {"type": "array", "items": item_type}
+        elif origin is dict or origin is Dict:
+            return {"type": "object"}
+        elif origin is Literal:
+            return {"type": "string", "enum": list(args)}
+        elif origin is Union:
+            # If >1 option, we have to run multiple times and aggregate results
+            union_types = [AgentCallable.arg_to_oai_type(py_type) for py_type in args]
+            out: Dict[str, Union[List[str], str]] = {}
+
+            for union_type in union_types:
+                for key, value in union_type.items():
+                    if key in out:
+                        if isinstance(out[key], list):
+                            out[key].append(value)
+                        else:
+                            out[key] = [out[key], value]
+                    else:
+                        out[key] = value
+
+            return out
+        elif arg in PYTHON_TO_OAI_SCHEMA:
+            return {"type": PYTHON_TO_OAI_SCHEMA[arg]}
+        else:
+            raise KeyError(
+                "Type {} is not an interpretable type for OpenAI.".format(str(arg))
+            )
+
+class AsyncAgentCallable(AgentCallable):
+    async def __call__(self, *args, **kwargs):
+        result = await self.func(*args, **kwargs)
+        return result
 
 def agent_callable(description: str, variable_description: dict[str, str]):
     """
@@ -142,18 +150,13 @@ def agent_callable(description: str, variable_description: dict[str, str]):
         variable_description (dict[str, str]): A dict with entries for each variable of the function describing what each variable is
     """
     def agent_callable_wrapper(func: Callable):
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            result = func(*args, **kwargs)
-            return result
+        # Handle async
+        if inspect.iscoroutinefunction(func) is False:
+            AC = AgentCallable
+        else:
+            AC = AsyncAgentCallable
 
-        setattr(wrapper, "agent_callable", True)
-
-        agent_json_payload = generate_tool_json_payload(
-            wrapper, description=description, variable_description=variable_description
-        )
-        setattr(wrapper, "agent_json_payload", agent_json_payload)
-
+        wrapper = update_wrapper(AC(func, description, variable_description), func)
         return wrapper
 
     return agent_callable_wrapper

--- a/agents/json_tool_gen.py
+++ b/agents/json_tool_gen.py
@@ -4,20 +4,21 @@ using python type hints and a thin decorator
 
 Sean Browning
 """
-from functools import update_wrapper
+
+import functools
 import inspect
+from types import NoneType
 from typing import (
-    List,
-    Union,
+    Any,
     Callable,
     Dict,
-    Any,
+    List,
     Literal,
-    get_type_hints,
-    get_origin,
+    Union,
     get_args,
+    get_origin,
+    get_type_hints,
 )
-from types import NoneType
 
 PYTHON_TO_OAI_SCHEMA = {
     str: "string",
@@ -29,116 +30,111 @@ PYTHON_TO_OAI_SCHEMA = {
     NoneType: "null",
 }
 
-class AgentCallable:
-    def __init__(self, func: Callable, description: str, variable_description: Dict[str, str]):
-        self.description = description
-        self.variable_description = variable_description
-        self.func = func
-        self.agent_json_payload = self.generate_tool_json_payload()
 
-    def __call__(self, *args, **kwargs):
-        result = self.func(*args, **kwargs)
-        return result
+def arg_to_oai_type(arg: Any) -> Dict[str, Any]:
+    """
+    Converting Python type hint to OpenAI type for JSON payload.
 
-    def generate_tool_json_payload(self) -> Dict[str, Any]:
-        """
-        Internal function used to generate OpenAI Function Calling JSON payload from function type hints.
-        """
-        hints = get_type_hints(self.func)
-        hints.pop("return", None) # Ignore return type
-        sig = inspect.signature(self.func)
-        missing_annotations = (set(sig.parameters.keys()) ^ {"self"}) - set(hints.keys())
-        missing_descriptions = (set(sig.parameters.keys()) ^ {"self"}) - set(
-            self.variable_description.keys()
+    Args:
+        arg (Any): A type hint for a specific argument of a function
+    Returns:
+        Dict[str, str]: Detailing the argument type and any possible choices (if a Literal or List)
+    Raises:
+        KeyError if type is not an interpretable type for OpenAI
+    """
+    origin = get_origin(arg)
+    args = get_args(arg)
+
+    if origin is list or origin is List:
+        item_type = arg_to_oai_type(args[0]) if args else {"type": "any"}
+        return {"type": "array", "items": item_type}
+    elif origin is dict or origin is Dict:
+        return {"type": "object"}
+    elif origin is Literal:
+        return {"type": "string", "enum": list(args)}
+    elif origin is Union:
+        # If >1 option, we have to run multiple times and aggregate results
+        union_types = [arg_to_oai_type(py_type) for py_type in args]
+        out: Dict[str, Union[List[str], str]] = {}
+
+        for union_type in union_types:
+            for key, value in union_type.items():
+                if key in out:
+                    if isinstance(out[key], list):
+                        out[key].append(value)
+                    else:
+                        out[key] = [out[key], value]
+                else:
+                    out[key] = value
+
+        return out
+    elif arg in PYTHON_TO_OAI_SCHEMA:
+        return {"type": PYTHON_TO_OAI_SCHEMA[arg]}
+    else:
+        raise KeyError(
+            "Type {} is not an interpretable type for OpenAI.".format(str(arg))
         )
 
-        if len(missing_annotations) > 0:
-            raise ValueError(
-                "agent_callable requires type hints for every argument! Missing type hints for {}: {}.".format(
-                    self.func.__name__, ", ".join(missing_annotations)
-                )
-            )
-        if len(missing_descriptions):
-            raise ValueError(
-                "agent_callable requires descriptions for every argument! Missing description for {}: {}.".format(
-                    self.func.__name__, ", ".join(missing_descriptions)
-                )
-            )
 
-        tool_json = {
-            "type": "function",
-            "function": {
-                "name": self.func.__name__,
-                "description": self.description,
-                "parameters": {
-                    "type": "object",
-                    "properties": {},
-                    "required": [variable for variable in hints.keys()],
-                    "additionalProperties": False,
-                },
-                "strict": True,
+def generate_tool_json_payload(
+    func: Callable, description: str, variable_description: Dict[str, str]
+) -> Dict[str, Any]:
+    """
+    Internal function used to generate OpenAI Function Calling JSON payload from function type hints.
+
+    Args:
+        func (Callable): The function to extract type hints from
+        description (str): A Description of the function
+        variable_description (Dict[str, str]): A dict with entries for each variable of the function describing what each variable is
+    Returns:
+        Dict[str, Any] A JSON payload to provide in the request body for OpenAI Function Calling
+    """
+    hints = get_type_hints(func)
+    hints.pop("return", None)  # Ignore return type
+    sig = inspect.signature(func)
+    missing_annotations = (set(sig.parameters.keys()) ^ {"self"}) - set(hints.keys())
+    missing_descriptions = (set(sig.parameters.keys()) ^ {"self"}) - set(
+        variable_description.keys()
+    )
+
+    if len(missing_annotations) > 0:
+        raise ValueError(
+            "agent_callable requires type hints for every argument! Missing type hints for {}: {}.".format(
+                func.__name__, ", ".join(missing_annotations)
+            )
+        )
+    if len(missing_descriptions):
+        raise ValueError(
+            "agent_callable requires descriptions for every argument! Missing description for {}: {}.".format(
+                func.__name__, ", ".join(missing_descriptions)
+            )
+        )
+
+    tool_json = {
+        "type": "function",
+        "function": {
+            "name": func.__name__,
+            "description": description,
+            "parameters": {
+                "type": "object",
+                "properties": {},
+                "required": [variable for variable in hints.keys()],
+                "additionalProperties": False,
             },
-        }
+            "strict": True,
+        },
+    }
 
-        for arg, hint in hints.items():
-            try:
-                arg_properties = self.arg_to_oai_type(hint)
-            except KeyError as e:
-                raise KeyError("Processing arg {} failed. {}".format(arg, str(e)))
-            arg_properties["description"] = self.variable_description[arg]
-            tool_json["function"]["parameters"]["properties"].update({arg: arg_properties})
+    for arg, hint in hints.items():
+        try:
+            arg_properties = arg_to_oai_type(hint)
+        except KeyError as e:
+            raise KeyError("Processing arg {} failed. {}".format(arg, str(e)))
+        arg_properties["description"] = variable_description[arg]
+        tool_json["function"]["parameters"]["properties"].update({arg: arg_properties})
 
-        return tool_json
-    
-    @staticmethod
-    def arg_to_oai_type(arg: Any) -> Dict[str, Any]:
-        """
-        Converting Python type hint to OpenAI type for JSON payload.
+    return tool_json
 
-        Args:
-            arg (Any): A type hint for a specific argument of a function
-        Returns:
-            Dict[str, str]: Detailing the argument type and any possible choices (if a Literal or List)
-        Raises:
-            KeyError if type is not an interpretable type for OpenAI
-        """
-        origin = get_origin(arg)
-        args = get_args(arg)
-
-        if origin is list or origin is List:
-            item_type = AgentCallable.arg_to_oai_type(args[0]) if args else {"type": "any"}
-            return {"type": "array", "items": item_type}
-        elif origin is dict or origin is Dict:
-            return {"type": "object"}
-        elif origin is Literal:
-            return {"type": "string", "enum": list(args)}
-        elif origin is Union:
-            # If >1 option, we have to run multiple times and aggregate results
-            union_types = [AgentCallable.arg_to_oai_type(py_type) for py_type in args]
-            out: Dict[str, Union[List[str], str]] = {}
-
-            for union_type in union_types:
-                for key, value in union_type.items():
-                    if key in out:
-                        if isinstance(out[key], list):
-                            out[key].append(value)
-                        else:
-                            out[key] = [out[key], value]
-                    else:
-                        out[key] = value
-
-            return out
-        elif arg in PYTHON_TO_OAI_SCHEMA:
-            return {"type": PYTHON_TO_OAI_SCHEMA[arg]}
-        else:
-            raise KeyError(
-                "Type {} is not an interpretable type for OpenAI.".format(str(arg))
-            )
-
-class AsyncAgentCallable(AgentCallable):
-    async def __call__(self, *args, **kwargs):
-        result = await self.func(*args, **kwargs)
-        return result
 
 def agent_callable(description: str, variable_description: dict[str, str]):
     """
@@ -149,14 +145,21 @@ def agent_callable(description: str, variable_description: dict[str, str]):
         description (str): A description of the function which will be shared with the language agent
         variable_description (dict[str, str]): A dict with entries for each variable of the function describing what each variable is
     """
-    def agent_callable_wrapper(func: Callable):
-        # Handle async
-        if inspect.iscoroutinefunction(func) is False:
-            AC = AgentCallable
-        else:
-            AC = AsyncAgentCallable
 
-        wrapper = update_wrapper(AC(func, description, variable_description), func)
+    def agent_callable_wrapper(func: Callable):
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            result = func(*args, **kwargs)
+            return result
+
+        # Generate the JSON payload needed for OpenAI Function Calling API
+        # and assign it to an attribute we can extract at Agent init time
+        json_payload = generate_tool_json_payload(
+            func, description, variable_description
+        )
+        setattr(wrapper, "agent_tool_payload", json_payload)
+
         return wrapper
 
     return agent_callable_wrapper

--- a/agents/json_tool_gen.py
+++ b/agents/json_tool_gen.py
@@ -1,0 +1,159 @@
+"""
+Automated generation of function calling JSON payload for OpenAI
+using python type hints and a thin decorator
+
+Sean Browning
+"""
+from functools import wraps
+import inspect
+from typing import (
+    Optional,
+    List,
+    Union,
+    Callable,
+    Dict,
+    Any,
+    Literal,
+    get_type_hints,
+    get_origin,
+    get_args,
+)
+from types import NoneType
+
+PYTHON_TO_OAI_SCHEMA = {
+    str: "string",
+    int: "integer",
+    float: "number",
+    bool: "boolean",
+    List: "array",
+    Dict: "object",
+    NoneType: "null",
+}
+
+
+def arg_to_oai_type(arg: Any) -> Dict[str, Any]:
+    """
+    Converting Python type hint to OpenAI type for JSON payload.
+
+    Args:
+        arg (Any): A type hint for a specific argument of a function
+    Returns:
+        Dict[str, str]: Detailing the argument type and any possible choices (if a Literal or List)
+    Raises:
+        KeyError if type is not an interpretable type for OpenAI
+    """
+    origin = get_origin(arg)
+    args = get_args(arg)
+
+    if origin is list or origin is List:
+        item_type = arg_to_oai_type(args[0]) if args else {"type": "any"}
+        return {"type": "array", "items": item_type}
+    elif origin is dict or origin is Dict:
+        return {"type": "object"}
+    elif origin is Literal:
+        return {"type": "string", "enum": list(args)}
+    elif origin is Union:
+        # If >1 option, we have to run multiple times and aggregate results
+        union_types = [arg_to_oai_type(py_type) for py_type in args]
+        out: Dict[str, Union[List[str], str]] = {}
+
+        for union_type in union_types:
+            for key, value in union_type.items():
+                if key in out:
+                    if isinstance(out[key], list):
+                        out[key].append(value)
+                    else:
+                        out[key] = [out[key], value]
+                else:
+                    out[key] = value
+
+        return out
+    elif arg in PYTHON_TO_OAI_SCHEMA:
+        return {"type": PYTHON_TO_OAI_SCHEMA[arg]}
+    else:
+        raise KeyError(
+            "Type {} is not an interpretable type for OpenAI.".format(str(arg))
+        )
+
+
+def generate_tool_json_payload(
+    func: Callable, description: str, variable_description: Dict[str, str]
+) -> Dict[str, Any]:
+    """
+    Internal function used to generate OpenAI Function Calling JSON payload from function type hints.
+
+    Args:
+        func (Callable): The function to extract type hints from
+        description (str): A Description of the function
+    """
+    hints = get_type_hints(func)
+    sig = inspect.signature(func)
+    missing_annotations = (set(sig.parameters.keys()) ^ {"self"}) - set(hints.keys())
+    missing_descriptions = (set(sig.parameters.keys()) ^ {"self"}) - set(
+        variable_description.keys()
+    )
+
+    if len(missing_annotations) > 0:
+        raise ValueError(
+            "agent_callable requires type hints for every argument! Missing type hints for {}: {}.".format(
+                func.__name__, ", ".join(missing_annotations)
+            )
+        )
+    if len(missing_descriptions):
+        raise ValueError(
+            "agent_callable requires descriptions for every argument! Missing description for {}: {}.".format(
+                func.__name__, ", ".join(missing_descriptions)
+            )
+        )
+
+    tool_json = {
+        "type": "function",
+        "function": {
+            "name": func.__name__,
+            "description": description,
+            "parameters": {
+                "type": "object",
+                "properties": {},
+                "required": [variable for variable in sig.parameters.keys()],
+                "addnProperties": False,
+            },
+            "strict": True,
+        },
+    }
+
+    for arg, hint in hints.items():
+        try:
+            arg_properties = arg_to_oai_type(hint)
+        except KeyError as e:
+            raise KeyError("Processing arg {} failed. {}".format(arg, str(e)))
+        arg_properties["description"] = variable_description[arg]
+        tool_json["function"]["parameters"]["properties"].update({arg: arg_properties})
+
+    return tool_json
+
+
+def agent_callable(description: str, variable_description: dict[str, str]):
+    """
+    Marks a method as accessible to a language agent
+    and generates required JSON payload by extracting type hints.
+
+    Args:
+        description (str): A description of the function which will be shared with the language agent
+        variable_description (dict[str, str]): A dict with entries for each variable of the function describing what each variable is
+    """
+    def agent_callable_wrapper(func: Callable):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            result = func(*args, **kwargs)
+            return result
+
+        setattr(wrapper, "agent_callable", True)
+
+        agent_json_payload = generate_tool_json_payload(
+            wrapper, description=description, variable_description=variable_description
+        )
+        setattr(wrapper, "agent_json_payload", agent_json_payload)
+
+        return wrapper
+
+    return agent_callable_wrapper

--- a/agents/json_tool_gen.py
+++ b/agents/json_tool_gen.py
@@ -45,7 +45,7 @@ class AgentCallable:
         Internal function used to generate OpenAI Function Calling JSON payload from function type hints.
         """
         hints = get_type_hints(self.func)
-        hints.pop("result", None) # Ignore return type
+        hints.pop("return", None) # Ignore return type
         sig = inspect.signature(self.func)
         missing_annotations = (set(sig.parameters.keys()) ^ {"self"}) - set(hints.keys())
         missing_descriptions = (set(sig.parameters.keys()) ^ {"self"}) - set(

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(
     packages=find_packages(include=["agents", "agents.*"]),
     install_requires=requirements,
     tests_require=[
-        "pytest",
+        "pytest", "pytest-mock"
     ]
 )

--- a/tests/test_auto_json.py
+++ b/tests/test_auto_json.py
@@ -1,0 +1,40 @@
+import pytest
+from pytest_mock import MockFixture
+import agents
+
+class DummyAgent(agents.Agent):
+    @agents.agent_callable("A tool the language agent can use", {"a": "a variable", "b": "another variable"})
+    def blah(self, a: str, b: int) -> str:
+        """
+        A tool the language agent can use
+        """
+        return ""
+
+class AsyncDummyAgent(DummyAgent):
+    @agents.async_agent_callable("A function named blech", {"d": "A variable of the letter d"})
+    async def blech(self, d: float) -> str:
+        return ""
+
+def test_json_payload_from_annotations(mocker: MockFixture) -> None:
+    """
+    Testing that decorated methods correctly
+    generate tools that can be used by an agent
+    """
+    _provider = mocker.Mock(spec=agents.AzureOpenAIProvider)
+
+    my_dummy = DummyAgent(agents.StopNoOp(), provider=_provider)
+
+    assert len(my_dummy.TOOLS) == 1, "Tool length is off!"
+    assert set(my_dummy._known_tools) == {"blah"}, f"Only found tools:{my_dummy._known_tools}"
+
+def test_json_payload_from_async_annotations(mocker: MockFixture) -> None:
+    """
+    Testing that decorated async methods correctly
+    generate tools that can be used by an agent
+    """
+    _provider = mocker.Mock(spec=agents.AzureOpenAIProvider)
+
+    my_dummy = AsyncDummyAgent(agents.StopNoOp(), provider=_provider)
+
+    assert len(my_dummy.TOOLS) == 2, "Tool length is off!"
+    assert set(my_dummy._known_tools) == {"blah", "blech"}, f"Only found tools:{my_dummy._known_tools}"


### PR DESCRIPTION
## Changes
- Closes #17
- Adds two new top-level decorators: `agent_callable` and `async_agent_callable`
  - Both decorate functions or methods and automatically produce the required JSON tool payload for OpenAI function calling
  - *requires type hinting all variables*
- Adds unit-test for the above
- Adds an additional class method for Agents called at init time to scan for methods that have been decorated as agent_callable and adds their JSON payload to the instance `TOOLS` attribute 
