### PR TITLE
Fixes to OpenAI Batch API asyncio deadlocking

### DIFF
--- a/agents/abstract.py
+++ b/agents/abstract.py
@@ -337,8 +337,8 @@ class _BatchAPIHelper(Generic[P], metaclass=abc.ABCMeta):
         for t in self.batch_tasks:
             t.cancel()
 
-            all_tasks = [self.task] + self.batch_tasks
-            await asyncio.gather(*all_tasks, return_exceptions=True)
+        all_tasks = [self.task] + self.batch_tasks
+        await asyncio.gather(*all_tasks, return_exceptions=True)
 
     @abc.abstractmethod
     def register_provider(self, provider: P):

--- a/agents/abstract.py
+++ b/agents/abstract.py
@@ -23,13 +23,13 @@ from typing import (
     Union,
 )
 
-from openai.types.chat import ChatCompletionMessage
+from openai.types.chat import ChatCompletionMessageParam, ChatCompletionMessage
 from openai.types.chat.chat_completion import ChatCompletion, Choice
 from pydantic import BaseModel, ValidationError
 
 logger = logging.getLogger(__name__)
 
-Message = Union[dict[str, str], ChatCompletionMessage]
+Message = Union[dict[str, str], ChatCompletionMessageParam]
 
 P = TypeVar("P", bound="_Provider")
 A = TypeVar("A", bound="_Agent")

--- a/agents/abstract.py
+++ b/agents/abstract.py
@@ -9,7 +9,6 @@ import logging
 import os
 from asyncio import Task, create_task, to_thread
 from dataclasses import dataclass, field
-from inspect import iscoroutinefunction
 from typing import (
     Any,
     Awaitable,
@@ -183,10 +182,7 @@ class _ToolCall(Generic[A], metaclass=abc.ABCMeta):
             res = self.errors
         else:
             try:
-                if iscoroutinefunction(self.func):
-                    res = await self.func(**self.kwargs)
-                else:
-                    res = await to_thread(self.func, **self.kwargs)
+                res = await to_thread(self.func, **self.kwargs)
             except ValidationError as e:
                 # Case: Handle pydantic validation errors by passing them back to the
                 # model to correct

--- a/agents/observability.py
+++ b/agents/observability.py
@@ -205,7 +205,7 @@ class _AzureProvider(
                 out.finish_reason = "tool_calls"
                 # Append GPT response to next payload
                 # NOTE: This has to come before the next step of parsing
-                ag.tool_res_payload.append(out.message)
+                ag.tool_res_payload.append(out.message.model_dump())
 
         logger.info(f"Received response: {out.message.content}")
 

--- a/agents/processors.py
+++ b/agents/processors.py
@@ -204,10 +204,7 @@ class SeqProcessor(_Processor):
 
         return out
 
-    async def _worker(
-        self,
-        worker_name: str
-    ):
+    async def _worker(self, worker_name: str):
         """
         Agent worker
         """

--- a/agents/processors.py
+++ b/agents/processors.py
@@ -154,9 +154,8 @@ class SeqProcessor(_Processor):
         :param kwargs: Additional named arguments passed to `agent_class` on init
         """
         self.n_workers = n_workers
-        self.batch_size = batch_size
 
-        super().__init__(data, agent_class, provider, n_retry, **kwargs)
+        super().__init__(data, agent_class, provider, batch_size, n_retry, **kwargs)
 
     async def process(self):
         # Either the workers we called for at init or the number of batches we have to process

--- a/agents/processors.py
+++ b/agents/processors.py
@@ -353,14 +353,9 @@ class AllCallProcessor(_Processor):
         try:
             while not self.in_q.empty():
                 for idx, retries_left, agent in self.dequeue(self.in_q):
-                    workers.append(
-                        asyncio.create_task(
-                            self._agent_handler(agent, idx, retries_left),
-                            name=f"agent-{idx}",
-                        )
-                    )
+                    workers.append(self._agent_handler(agent, idx, retries_left))
                 # Wait for all agents to complete
-                await asyncio.gather(*workers)
+                await asyncio.wait(workers)
         finally:
             self.pbar.close()
 

--- a/agents/processors.py
+++ b/agents/processors.py
@@ -233,8 +233,6 @@ class SeqProcessor(_Processor):
                 logger.error(f"[_worker - {worker_name}]: Task {id} failed, {str(e)}")
                 errored = True
 
-            self.in_q.task_done()
-
             if errored:
                 retry_left -= 1
                 if retry_left < 0:

--- a/agents/processors.py
+++ b/agents/processors.py
@@ -230,6 +230,8 @@ class SeqProcessor(_Processor):
                 logger.error(f"[_worker - {worker_name}]: Task {id} failed, {str(e)}")
                 errored = True
 
+            self.in_q.task_done()
+
             if errored:
                 retry_left -= 1
                 if retry_left < 0:
@@ -397,8 +399,6 @@ class AllCallProcessor(_Processor):
         except Exception as e:
             logger.error(f"[_agent_handler]: Task {id} failed, {str(e)}")
             errored = True
-
-        self.in_q.task_done()
 
         if errored:
             retry_left -= 1

--- a/agents/providers/openai.py
+++ b/agents/providers/openai.py
@@ -66,7 +66,6 @@ class OpenAIBatchAPIHelper(_BatchAPIHelper["AzureOpenAIBatchProvider"]):
             disable=provider.quiet,
         )
 
-        self.pbar_lock = asyncio.Lock()
         # Create a Semaphore to ensure only n_workers batches running concurrently
         self.lock = asyncio.Semaphore(self.n_workers)
         self.task = asyncio.create_task(self._batcher(), name="OpenAIBatchHelper")
@@ -107,10 +106,19 @@ class OpenAIBatchAPIHelper(_BatchAPIHelper["AzureOpenAIBatchProvider"]):
                     self.provider.batch_q.task_done()
 
                 # Wait on the batch tasks
-                # DEBUG: Remove assigns later
-                finished_batches, processing_batches = await asyncio.wait(
-                    self.batch_tasks, timeout=self.timeout
-                )
+                if len(self.batch_tasks):
+                    finished_batches, processing_batches = await asyncio.wait(
+                        self.batch_tasks, timeout=self.timeout
+                    )
+
+                    # Check for exceptions and remove any completed batches so we don't keep checking
+                    for batch_task in finished_batches:
+                        if (batch_task_err := batch_task.exception()) is not None:
+                            logger.error(
+                                f"[OpenAIBatchAPIHelper]: Batch task failed! {str(batch_task_err)}"
+                            )
+                        # Remove completed batches
+                        self.batch_tasks.remove(batch_task)
 
                 # Case: Nothing to submit or less than max items and we're still waiting for
                 # a semaphore
@@ -133,10 +141,10 @@ class OpenAIBatchAPIHelper(_BatchAPIHelper["AzureOpenAIBatchProvider"]):
         """
         # Create batch file, send to OpenAI and execute
         async with self.lock:
-            batch_file = await self.provider.send_batch(batch)
             try:
-                async with self.pbar_lock:
-                    self.pbar.update(1)
+                batch_file = await self.provider.send_batch(batch)
+                self.pbar.update(1)
+                self.pbar.refresh()
                 batch_task = await self.provider.create_batch_task(
                     batch_file, timeout=self.api_timeout
                 )
@@ -166,10 +174,13 @@ class OpenAIBatchAPIHelper(_BatchAPIHelper["AzureOpenAIBatchProvider"]):
                     if not fut.done():
                         # If the future is not done, set it to an exception
                         fut.set_exception(e)
+
+                # Signal to batcher as well
+                raise e
+
             finally:
-                async with self.pbar_lock:
-                    self.pbar.update(-1)
-                    self.pbar.refresh()
+                self.pbar.update(-1)
+                self.pbar.refresh()
 
 
 class _AzureProvider(Generic[A, ProviderMode], _Provider[A]):
@@ -402,7 +413,32 @@ class AzureOpenAIBatchProvider(_AzureProvider[A, Literal["batch"]]):
         await self.batch_q.put(task)
 
         # Await the result
-        out = await self.batch_out[task_id]
+        done = False
+        while not done:
+            try:
+                # Poll health of batcher
+                await asyncio.wait_for(
+                    asyncio.shield(self.batch_handler.task), timeout=0.5
+                )
+            except asyncio.TimeoutError:
+                # No issues
+                pass
+            except Exception as e:
+                # TODO: Write exception class so I can make this halting
+                logger.error(
+                    "[AzureOpenAIBatchProvider]: BatchAPI Helper task raised an exception before query was complete!\n{str(e)}"
+                )
+                raise e
+
+            # Poll every 1s for the query result
+            try:
+                out = await asyncio.wait_for(
+                    asyncio.shield(self.batch_out[task_id]), timeout=1
+                )
+                done = True
+            except asyncio.TimeoutError:
+                # Our task isn't done, retry
+                continue
 
         # remove the future from the output dict
         self.batch_out.pop(task_id, None)

--- a/agents/providers/openai.py
+++ b/agents/providers/openai.py
@@ -67,7 +67,7 @@ class OpenAIBatchAPIHelper(_BatchAPIHelper["AzureOpenAIBatchProvider"]):
                 # Await new messages to load into the batch
                 # - Until we hit our max batch size, or
                 # - Until we've waited for the time indicated (default 2s)
-                while len(batch) <= self.batch_size:
+                while len(batch) < self.batch_size:
                     time_remaining = self.timeout - (
                         asyncio.get_running_loop().time() - batch_poll_start
                     )
@@ -82,15 +82,14 @@ class OpenAIBatchAPIHelper(_BatchAPIHelper["AzureOpenAIBatchProvider"]):
                         continue
                     batch.append(req)
                     self.provider.batch_q.task_done()
-                # Case: Nothing to submit
-                # - Just re-run until we do have items
-                if len(batch) == 0:
+                # Case: Nothing to submit or less than max items and we're still waiting for
+                # a semaphore
+                if len(batch) == 0 or (len(batch) < self.batch_size and self.lock.locked()):
                     continue
 
-                async with self.lock:
-                    self.batch_tasks.append(
-                        asyncio.create_task(self._batch_handler(batch))
-                    )
+                self.batch_tasks.append(
+                    asyncio.create_task(self._batch_handler(batch))
+                )
             except (asyncio.CancelledError, GeneratorExit):
                 # If the task was cancelled, we should exit the loop
                 logger.info("OpenAIBatchHelper closing.")
@@ -102,43 +101,44 @@ class OpenAIBatchAPIHelper(_BatchAPIHelper["AzureOpenAIBatchProvider"]):
         when finished.
         """
         # Create batch file, send to OpenAI and execute
-        batch_file = await self.provider.send_batch(batch)
-        try:
-            async with self.pbar_lock:
-                self.pbar.update(1)
-            batch_task = await self.provider.create_batch_task(
-                batch_file, timeout=self.api_timeout
-            )
-
-            if batch_task.errors is not None and batch_task.errors.data is not None:
-                # Batch returned an error. Raise
-                errors = "\n".join(
-                    f"[{err.code}]: {err.message}" for err in batch_task.errors.data
-                )
-                logger.error(f"Batch {batch_task.id} returned an error:\n{errors}")
-                raise RuntimeError(
-                    f"Batch {batch_task.id} returned an error:\n{errors}"
+        async with self.lock:
+            batch_file = await self.provider.send_batch(batch)
+            try:
+                async with self.pbar_lock:
+                    self.pbar.update(1)
+                batch_task = await self.provider.create_batch_task(
+                    batch_file, timeout=self.api_timeout
                 )
 
-            # Get results
-            results = await self.provider.get_batch_results(batch_task)
+                if batch_task.errors is not None and batch_task.errors.data is not None:
+                    # Batch returned an error. Raise
+                    errors = "\n".join(
+                        f"[{err.code}]: {err.message}" for err in batch_task.errors.data
+                    )
+                    logger.error(f"Batch {batch_task.id} returned an error:\n{errors}")
+                    raise RuntimeError(
+                        f"Batch {batch_task.id} returned an error:\n{errors}"
+                    )
 
-            # Write out results to dict for agents to pick up
-            for result in results:
-                self.provider.batch_out[result["custom_id"]].set_result(
-                    ChatCompletion.model_validate(result["response"]["body"])
-                )
-        except Exception as e:
-            # propagate the exception to the futures
-            for _, v in self.provider.batch_out.items():
-                if not v.done():
-                    # If the future is not done, set it to an exception
-                    v.set_exception(e)
-            raise e
-        finally:
-            async with self.pbar_lock:
-                self.pbar.update(-1)
-                self.pbar.refresh()
+                # Get results
+                results = await self.provider.get_batch_results(batch_task)
+
+                # Write out results to dict for agents to pick up
+                for result in results:
+                    self.provider.batch_out[result["custom_id"]].set_result(
+                        ChatCompletion.model_validate(result["response"]["body"])
+                    )
+            except Exception as e:
+                # propagate the exception to the futures
+                for _, v in self.provider.batch_out.items():
+                    if not v.done():
+                        # If the future is not done, set it to an exception
+                        v.set_exception(e)
+                raise e
+            finally:
+                async with self.pbar_lock:
+                    self.pbar.update(-1)
+                    self.pbar.refresh()
 
 
 class _AzureProvider(Generic[A, ProviderMode], _Provider[A]):

--- a/agents/providers/openai.py
+++ b/agents/providers/openai.py
@@ -4,7 +4,7 @@ import logging
 import os
 from io import BytesIO, StringIO
 from typing import Dict, List, Literal, Optional, Tuple, Union, TypeVar, Generic
-
+from httpx import HttpxBinaryResponseContent
 import backoff
 import openai
 import tqdm.asyncio as tqdm
@@ -416,7 +416,9 @@ class AzureOpenAIBatchProvider(_AzureProvider[A, Literal["batch"]]):
 
         :return: An OpenAI File object representing the uploaded batch file
         """
-        file_name, file_content, mime_type = await asyncio.to_thread(self._create_batch_file, tasks)
+        file_name, file_content, mime_type = await asyncio.to_thread(
+            self._create_batch_file, tasks
+        )
         return await self.llm.files.create(
             file=(file_name, file_content, mime_type), purpose="batch", **kwargs
         )
@@ -463,16 +465,22 @@ class AzureOpenAIBatchProvider(_AzureProvider[A, Literal["batch"]]):
         if batch.status != "completed" or batch.output_file_id is None:
             raise ValueError("Batch status was not 'completed'! Got: " + batch.status)
 
-        results = []
         result_stream = await self.llm.files.content(batch.output_file_id)
+        results = await asyncio.to_thread(
+            self._response_from_bytes, result_stream.content
+        )
+        return results
 
+    @staticmethod
+    def _response_from_bytes(stream: bytes) -> List[Dict]:
+        out = []
         with BytesIO() as buffer:
-            buffer.write(result_stream.content)
+            buffer.write(stream)
             result_text = buffer.getvalue().decode("utf-8")
             for line in result_text.splitlines():
-                results.append(json.loads(line))
+                out.append(json.loads(line))
 
-        return results
+        return out
 
 
 class OpenAIProvider(AzureOpenAIProvider):

--- a/agents/providers/openai.py
+++ b/agents/providers/openai.py
@@ -416,7 +416,7 @@ class AzureOpenAIBatchProvider(_AzureProvider[A, Literal["batch"]]):
 
         :return: An OpenAI File object representing the uploaded batch file
         """
-        file_name, file_content, mime_type = self._create_batch_file(tasks)
+        file_name, file_content, mime_type = await asyncio.to_thread(self._create_batch_file, tasks)
         return await self.llm.files.create(
             file=(file_name, file_content, mime_type), purpose="batch", **kwargs
         )

--- a/agents/providers/openai.py
+++ b/agents/providers/openai.py
@@ -105,6 +105,13 @@ class OpenAIBatchAPIHelper(_BatchAPIHelper["AzureOpenAIBatchProvider"]):
                         continue
                     batch.append(req)
                     self.provider.batch_q.task_done()
+
+                # Wait on the batch tasks
+                # DEBUG: Remove assigns later
+                finished_batches, processing_batches = await asyncio.wait(
+                    self.batch_tasks, timeout=self.timeout
+                )
+
                 # Case: Nothing to submit or less than max items and we're still waiting for
                 # a semaphore
                 if len(batch) == 0 or (
@@ -113,6 +120,7 @@ class OpenAIBatchAPIHelper(_BatchAPIHelper["AzureOpenAIBatchProvider"]):
                     continue
 
                 self.batch_tasks.append(asyncio.create_task(self._batch_handler(batch)))
+
             except (asyncio.CancelledError, GeneratorExit):
                 # If the task was cancelled, we should exit the loop
                 logger.info("OpenAIBatchHelper closing.")

--- a/agents/providers/openai.py
+++ b/agents/providers/openai.py
@@ -3,8 +3,8 @@ import json
 import logging
 import os
 from io import BytesIO, StringIO
-from typing import Dict, List, Literal, Optional, Tuple, Union, TypeVar, Generic
-from httpx import HttpxBinaryResponseContent
+from typing import Dict, Generic, List, Literal, Optional, Tuple, TypeVar, Union
+
 import backoff
 import openai
 import tqdm.asyncio as tqdm
@@ -13,7 +13,7 @@ from openai.types.batch import Batch
 from openai.types.chat import ChatCompletion, ChatCompletionMessageParam
 from openai.types.file_object import FileObject
 
-from ..abstract import _BatchAPIHelper, _Provider, A
+from ..abstract import A, _BatchAPIHelper, _Provider
 from ..tools import OpenAIToolCall
 
 DEFAULT_BATCH_SIZE = 1000

--- a/agents/providers/openai.py
+++ b/agents/providers/openai.py
@@ -3,15 +3,29 @@ import json
 import logging
 import os
 from io import BytesIO, StringIO
-from typing import Dict, Generic, List, Literal, Optional, Tuple, TypeVar, Union
+from typing import (
+    Dict,
+    Generic,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+    TypedDict,
+)
 
 import backoff
 import openai
 import tqdm.asyncio as tqdm
 from azure.identity import ClientSecretCredential, InteractiveBrowserCredential
-from openai.types.batch import Batch
 from openai.types.chat import ChatCompletion, ChatCompletionMessageParam
-from openai.types.file_object import FileObject
+from openai.types import (
+    EmbeddingCreateParams,
+    CompletionCreateParams,
+    Batch,
+    FileObject,
+)
 
 from ..abstract import A, _BatchAPIHelper, _Provider
 from ..tools import OpenAIToolCall
@@ -20,6 +34,15 @@ DEFAULT_BATCH_SIZE = 1000
 ProviderMode = TypeVar("ProviderMode", Literal["chat"], Literal["batch"])
 
 logger = logging.getLogger(__name__)
+
+
+# HACK: OpenAI does not (yet) implement batch request input type
+# See: https://github.com/openai/openai-python/issues/1937
+class BatchRequestInput(TypedDict):
+    custom_id: str
+    method: Literal["POST"]
+    url: Literal["/v1/chat/completions", "/v1/embeddings", "/v1/completions"]
+    body: Union[EmbeddingCreateParams, CompletionCreateParams]
 
 
 class OpenAIBatchAPIHelper(_BatchAPIHelper["AzureOpenAIBatchProvider"]):
@@ -95,7 +118,7 @@ class OpenAIBatchAPIHelper(_BatchAPIHelper["AzureOpenAIBatchProvider"]):
                 logger.info("OpenAIBatchHelper closing.")
                 break
 
-    async def _batch_handler(self, batch: List[ChatCompletionMessageParam]) -> None:
+    async def _batch_handler(self, batch: List[BatchRequestInput]) -> None:
         """
         A handler method that submits the batch of tasks to OpenAI and retrieves the results
         when finished.
@@ -130,11 +153,11 @@ class OpenAIBatchAPIHelper(_BatchAPIHelper["AzureOpenAIBatchProvider"]):
                     )
             except Exception as e:
                 # propagate the exception to the futures
-                for _, v in self.provider.batch_out.items():
-                    if not v.done():
+                for batch_item in batch:
+                    fut = self.provider.batch_out[batch_item["custom_id"]]
+                    if not fut.done():
                         # If the future is not done, set it to an exception
-                        v.set_exception(e)
-                raise e
+                        fut.set_exception(e)
             finally:
                 async with self.pbar_lock:
                     self.pbar.update(-1)
@@ -384,7 +407,7 @@ class AzureOpenAIBatchProvider(_AzureProvider[A, Literal["batch"]]):
 
     @staticmethod
     def _create_batch_file(
-        tasks: List[ChatCompletionMessageParam],
+        tasks: List[BatchRequestInput],
     ) -> Tuple[str, bytes, str]:
         """
         Create a batch file for the OpenAI Batch API
@@ -405,7 +428,7 @@ class AzureOpenAIBatchProvider(_AzureProvider[A, Literal["batch"]]):
 
     async def send_batch(
         self,
-        tasks: List[ChatCompletionMessageParam],
+        tasks: List[BatchRequestInput],
         **kwargs,
     ) -> FileObject:
         """

--- a/agents/providers/openai.py
+++ b/agents/providers/openai.py
@@ -290,7 +290,7 @@ class _AzureProvider(Generic[A, ProviderMode], _Provider[A]):
                 out.finish_reason = "tool_calls"
                 # Append GPT response to next payload
                 # NOTE: This has to come before the next step of parsing
-                ag.tool_res_payload.append(out.message)
+                ag.tool_res_payload.append(out.message.model_dump())
 
         logger.info(f"Received response: {out.message.content}")
 

--- a/agents/providers/openai.py
+++ b/agents/providers/openai.py
@@ -84,12 +84,12 @@ class OpenAIBatchAPIHelper(_BatchAPIHelper["AzureOpenAIBatchProvider"]):
                     self.provider.batch_q.task_done()
                 # Case: Nothing to submit or less than max items and we're still waiting for
                 # a semaphore
-                if len(batch) == 0 or (len(batch) < self.batch_size and self.lock.locked()):
+                if len(batch) == 0 or (
+                    len(batch) < self.batch_size and self.lock.locked()
+                ):
                     continue
 
-                self.batch_tasks.append(
-                    asyncio.create_task(self._batch_handler(batch))
-                )
+                self.batch_tasks.append(asyncio.create_task(self._batch_handler(batch)))
             except (asyncio.CancelledError, GeneratorExit):
                 # If the task was cancelled, we should exit the loop
                 logger.info("OpenAIBatchHelper closing.")


### PR DESCRIPTION
## Changes
- query tasks check for Batcher heartbeat, will raise if not running
- Awaiting query task result now handled in a loop for easier debugging
- Batcher will now check on batch tasks each iteration and signal on failure
- Finished batch tasks now pruned from list as they're completed
- send_batch call now moved in try block to avoid undetected fail
- removed pbar lock as it was superfluous
- Converting ChatCompletion objects in tool_call_res to dictionary to avoid failing upon serialization
- Defined BatchRequestInput class since OpenAI doesn't have this